### PR TITLE
feat(config): Turn off `import/prefer-default-export`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1318,7 +1318,7 @@ Other Code Conventions:
   <a name="modules--prefer-default-export"></a>
   - [10.6](#modules--prefer-default-export) In modules with a single export, prefer default export over named export.
  eslint: [`import/prefer-default-export`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md)
-    > Why? To encourage more files that only ever export one thing, which is better for readability and maintainability.
+    > Declaring a default should not be required regardless of the number of exports in your module. Default exports allow consumers to rename it and that makes bulk refactoring more difficult. By using named exports consumers will use that name providing consistent naming everywhere. Default exports are necessary for CommonJS modules. If your project must support consumers that use CommonJS you should consider enabling this rule.
 
     ```javascript
     // bad

--- a/packages/eslint-config-zillow-base/rules/imports.js
+++ b/packages/eslint-config-zillow-base/rules/imports.js
@@ -160,7 +160,7 @@ module.exports = {
 
     // Require modules with a single export to use a default export
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
-    'import/prefer-default-export': 'error',
+    'import/prefer-default-export': 'off',
 
     // Restrict which files can be imported in a given folder
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md

--- a/packages/eslint-plugin-zillow/test/eslint-plugin-zillow.test.js
+++ b/packages/eslint-plugin-zillow/test/eslint-plugin-zillow.test.js
@@ -55,7 +55,7 @@ describe('eslint-plugin-zillow', () => {
                 rules: {
                     'zillow/react/jsx-indent': ['off', 4],
                     'max-len': ['warn', 100, 4, { ignoreComments: false }],
-                    'zillow/import/prefer-default-export': 'error',
+                    'zillow/import/prefer-default-export': 'off',
                 },
             },
         });


### PR DESCRIPTION
It's a valid pattern to have only named exports in a file so there's no reason to enforce providing a default export.