### PR TITLE
fix(config): Updates the label-has-associated-contol

### DIFF
--- a/packages/eslint-config-zillow/rules/react-a11y.js
+++ b/packages/eslint-config-zillow/rules/react-a11y.js
@@ -54,7 +54,7 @@ module.exports = {
       labelComponents: [],
       labelAttributes: [],
       controlComponents: [],
-      assert: 'both',
+      assert: 'either',
       depth: 25
     }],
 


### PR DESCRIPTION
Changes the `assert` property from "both" to "either". WCAG 2.1
guidelines only require one accepted method be followed.