### PR TITLE
fix(preset): class-properties and private-methods need to have same loose value

### DIFF
--- a/packages/babel-preset-zillow/index.js
+++ b/packages/babel-preset-zillow/index.js
@@ -108,6 +108,8 @@ module.exports = declare((api, options) => {
 
             // need to hoist this above (possible) class transformer, otherwise it explodes
             [require('@babel/plugin-proposal-class-properties'), { loose: true }],
+            // class-properties and private-methods must have the same "loose" value
+            [require('@babel/plugin-proposal-private-methods'), { loose: true }],
 
             // prettier-ignore
             !isNode &&

--- a/packages/babel-preset-zillow/package.json
+++ b/packages/babel-preset-zillow/package.json
@@ -29,6 +29,7 @@
     "@babel/helper-plugin-utils": "^7.10.4",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
+    "@babel/plugin-proposal-private-methods": "^7.13.0",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-classes": "^7.10.4",
     "@babel/plugin-transform-computed-properties": "^7.10.4",


### PR DESCRIPTION
Started getting the following warning recently:

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
        ["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```

Found a discussion in another projects that seemed similar:
https://github.com/nuxt/nuxt.js/issues/9224

I actually tried this fix already, unfortunately it doesn't seem to resolve the warning. My current workaround is to include the class-properties and private-methods plugins myself in the babel.config.js where the babel-plugin-zillow preset is being used.
